### PR TITLE
titulo das paginas adicionado

### DIFF
--- a/lib/pages/conulstas_page.dart
+++ b/lib/pages/conulstas_page.dart
@@ -1,3 +1,4 @@
+import 'package:clinast/widgets/titulo_pagina.dart';
 import 'package:flutter/material.dart';
 
 class ConsultasPage extends StatelessWidget {
@@ -5,9 +6,16 @@ class ConsultasPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // construcao da pagina aqui
-    return const Center(
-      child: Text("PAGINA CONSULTAS EM BRANCO"),
+    return const Column(
+      children: <Widget>[
+        TituloPagina(),
+        Expanded(
+            child: Center(
+                child: Text(
+          "TABELA CONSULTAS AQUI!",
+          style: TextStyle(fontSize: 48),
+        )))
+      ],
     );
   }
 }

--- a/lib/pages/doutores_page.dart
+++ b/lib/pages/doutores_page.dart
@@ -1,3 +1,4 @@
+import 'package:clinast/widgets/titulo_pagina.dart';
 import 'package:flutter/material.dart';
 
 class DoutoresPage extends StatelessWidget {
@@ -5,9 +6,16 @@ class DoutoresPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // construcao da pagina aqui
-    return const Center(
-      child: Text("PAGINA DOUTORES EM BRANCO"),
+    return const Column(
+      children: <Widget>[
+        TituloPagina(),
+        Expanded(
+            child: Center(
+                child: Text(
+          "TABELA DOUTORES AQUI!",
+          style: TextStyle(fontSize: 48),
+        )))
+      ],
     );
   }
 }

--- a/lib/pages/funcionarios_page.dart
+++ b/lib/pages/funcionarios_page.dart
@@ -1,3 +1,4 @@
+import 'package:clinast/widgets/titulo_pagina.dart';
 import 'package:flutter/material.dart';
 
 class FuncionariosPage extends StatelessWidget {
@@ -5,9 +6,16 @@ class FuncionariosPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // construcao da pagina aqui
-    return const Center(
-      child: Text("PAGINA FUNCIONARIOS EM BRANCO"),
+    return const Column(
+      children: <Widget>[
+        TituloPagina(),
+        Expanded(
+            child: Center(
+                child: Text(
+          "TABELA FUNCIONARIOS AQUI!",
+          style: TextStyle(fontSize: 48),
+        )))
+      ],
     );
   }
 }

--- a/lib/pages/pacientes_page.dart
+++ b/lib/pages/pacientes_page.dart
@@ -1,3 +1,4 @@
+import 'package:clinast/widgets/titulo_pagina.dart';
 import 'package:flutter/material.dart';
 
 class PacientesPage extends StatelessWidget {
@@ -5,9 +6,16 @@ class PacientesPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // construcao da pagina aqui
-    return const Center(
-      child: Text("PAGINA PACIENTES EM BRANCO"),
+    return const Column(
+      children: <Widget>[
+        TituloPagina(),
+        Expanded(
+            child: Center(
+                child: Text(
+          "TABELA PACIENTES AQUI!",
+          style: TextStyle(fontSize: 48),
+        )))
+      ],
     );
   }
 }

--- a/lib/pages/pagamentos_page.dart
+++ b/lib/pages/pagamentos_page.dart
@@ -1,3 +1,4 @@
+import 'package:clinast/widgets/titulo_pagina.dart';
 import 'package:flutter/material.dart';
 
 class PagamentosPage extends StatelessWidget {
@@ -5,9 +6,16 @@ class PagamentosPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // construcao da pagina aqui
-    return const Center(
-      child: Text("PAGINA PAGAMENTOS EM BRANCO"),
+    return const Column(
+      children: <Widget>[
+        TituloPagina(),
+        Expanded(
+            child: Center(
+                child: Text(
+          "TABELA PAGAMENTOS AQUI!",
+          style: TextStyle(fontSize: 48),
+        )))
+      ],
     );
   }
 }

--- a/lib/pages/resumo_page.dart
+++ b/lib/pages/resumo_page.dart
@@ -1,3 +1,4 @@
+import 'package:clinast/widgets/titulo_pagina.dart';
 import 'package:flutter/material.dart';
 
 class ResumoPage extends StatelessWidget {
@@ -5,9 +6,16 @@ class ResumoPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // construcao da pagina aqui
-    return const Center(
-      child: Text("PAGINA RESUMO EM BRANCO"),
+    return const Column(
+      children: <Widget>[
+        TituloPagina(),
+        Expanded(
+            child: Center(
+                child: Text(
+          "DASHBOARD AQUI!",
+          style: TextStyle(fontSize: 48),
+        )))
+      ],
     );
   }
 }

--- a/lib/strings/strings.dart
+++ b/lib/strings/strings.dart
@@ -1,0 +1,5 @@
+const tituloPagina = "Titulo da Pagina";
+const descricaoPagina = "Descricao da Pagina";
+
+const textoBotaoExportar = "Exportar";
+const textoBotaoAdicionar = "Novo Item";

--- a/lib/strings/strings.dart
+++ b/lib/strings/strings.dart
@@ -1,5 +1,0 @@
-const tituloPagina = "Titulo da Pagina";
-const descricaoPagina = "Descricao da Pagina";
-
-const textoBotaoExportar = "Exportar";
-const textoBotaoAdicionar = "Novo Item";

--- a/lib/widgets/titulo_pagina.dart
+++ b/lib/widgets/titulo_pagina.dart
@@ -1,4 +1,3 @@
-import 'package:clinast/strings/strings.dart';
 import 'package:flutter/material.dart';
 
 class TituloPagina extends StatelessWidget {
@@ -9,6 +8,8 @@ class TituloPagina extends StatelessWidget {
     final ButtonStyle style =
         ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
     const TextStyle botaoStyle = TextStyle(fontSize: 18);
+    const tituloPagina = "TITULO PAGINA";
+    const descricaoPagina = "DESCRICAO DA PAGINA";
     return Row(
       children: <Widget>[
         Expanded(
@@ -44,7 +45,7 @@ class TituloPagina extends StatelessWidget {
                       ),
                       Padding(padding: EdgeInsets.all(2)),
                       Text(
-                        textoBotaoExportar,
+                        "Exportar",
                         style: botaoStyle,
                       ),
                     ],
@@ -61,7 +62,7 @@ class TituloPagina extends StatelessWidget {
                       ),
                       Padding(padding: EdgeInsets.all(2)),
                       Text(
-                        textoBotaoAdicionar,
+                        "Novo Item",
                         style: botaoStyle,
                       ),
                     ],

--- a/lib/widgets/titulo_pagina.dart
+++ b/lib/widgets/titulo_pagina.dart
@@ -1,0 +1,77 @@
+import 'package:clinast/strings/strings.dart';
+import 'package:flutter/material.dart';
+
+class TituloPagina extends StatelessWidget {
+  const TituloPagina({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ButtonStyle style =
+        ElevatedButton.styleFrom(textStyle: const TextStyle(fontSize: 20));
+    const TextStyle botaoStyle = TextStyle(fontSize: 18);
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            child: const Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  tituloPagina,
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
+                ),
+                Text(
+                  descricaoPagina,
+                  style: TextStyle(fontWeight: FontWeight.w500),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Center(
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: <Widget>[
+                ElevatedButton(
+                  style: style,
+                  onPressed: () {},
+                  child: const Row(
+                    children: [
+                      Icon(
+                        (Icons.upgrade),
+                      ),
+                      Padding(padding: EdgeInsets.all(2)),
+                      Text(
+                        textoBotaoExportar,
+                        style: botaoStyle,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  style: style,
+                  onPressed: () {},
+                  child: const Row(
+                    children: [
+                      Icon(
+                        (Icons.add),
+                      ),
+                      Padding(padding: EdgeInsets.all(2)),
+                      Text(
+                        textoBotaoAdicionar,
+                        style: botaoStyle,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
titulo da pagina está:
- encapsulado em widgets/titulo_pagina.dart
- responsivo
não está:
- dinamico (titulo permanece generico)
  a solução de imediado seria remover a encapsulacao e construir o titulo em todas as paginas 1:1, devido a ineficiencia dessa solucao, estarei trabalhando em outro widget e retornando aqui quando tiver uma solucao mais adequada.